### PR TITLE
Deprecate: Verify Email Oob Function

### DIFF
--- a/apps/backend/src/lib/firebase/auth.ts
+++ b/apps/backend/src/lib/firebase/auth.ts
@@ -38,6 +38,9 @@ export async function verifyEmail(user: User, errorCb: (error: ErrorCallback) =>
 }
 
 /**
+ * @deprecated This function is deprecated and will be removed in the future. All email
+ *             verifications will automatically be handled by Firebase Hosting.
+ *
  * Verifies a user's email address using an out-of-band (OOB) code received through email.
  *
  * @param oobCode The OOB code received in the email verification link.

--- a/apps/backend/src/lib/firebase/auth.ts
+++ b/apps/backend/src/lib/firebase/auth.ts
@@ -104,7 +104,8 @@ export async function signUpEmailPassword(
 ) {
   try {
     errorCb(null);
-    await createUserWithEmailAndPassword(auth, email, password);
+    const { user } = await createUserWithEmailAndPassword(auth, email, password);
+    if (!user.emailVerified) sendEmailVerification(user);
   } catch (error) {
     if (dev) console.error(error);
     if (!(error instanceof FirebaseError)) throw new Error('Caught unknown error!');

--- a/apps/backend/src/lib/firebase/auth.ts
+++ b/apps/backend/src/lib/firebase/auth.ts
@@ -104,8 +104,7 @@ export async function signUpEmailPassword(
 ) {
   try {
     errorCb(null);
-    const { user } = await createUserWithEmailAndPassword(auth, email, password);
-    if (!user.emailVerified) await sendEmailVerification(user);
+    await createUserWithEmailAndPassword(auth, email, password);
   } catch (error) {
     if (dev) console.error(error);
     if (!(error instanceof FirebaseError)) throw new Error('Caught unknown error!');
@@ -133,8 +132,7 @@ export async function signInEmailPassword(
 ) {
   try {
     errorCb(null);
-    const { user } = await signInWithEmailAndPassword(auth, email, password);
-    if (!user.emailVerified) await sendEmailVerification(user);
+    await signInWithEmailAndPassword(auth, email, password);
   } catch (error) {
     if (dev) console.error(error);
     if (!(error instanceof FirebaseError)) throw new Error('Caught non-Firebase error!');


### PR DESCRIPTION
1. Deprecated `verifyEmailOob` function because Firebase Hosting will automatically resolve it.
2. Removed `sendEmailVerification` calls from `signInEmailPassword` as the client may get rate-limited.