### PR TITLE
refactor(backend): FOR FILE UPLOAD

### DIFF
--- a/apps/backend/src/lib/components/FileUpload.svelte
+++ b/apps/backend/src/lib/components/FileUpload.svelte
@@ -37,7 +37,7 @@
       filePassword: yup
         .string()
         .required('File password is required')
-        .min(8, 'Password must at least be 8 characters longs')
+        .min(8, 'Password must at least be 8 characters long')
         .matches(
           /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
           'Password must contain at least 1 lowercase letter, 1 uppercase letter, 1 number, and 1 special character'
@@ -77,9 +77,10 @@
         file_owner_id: $authStore.uid,
         file_encryption_hash: filePwdHash,
         file_encryption_iv: '',
-        file_permissions: [],
+        file_permissions: [$authStore.uid],
         updated_at: serverTimestamp(),
         created_at: serverTimestamp(),
+        self_destruct: false,
       };
 
       const docRef = doc(colFilesRef, formFileName);

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -20,4 +20,3 @@ export * from './https/onCall/file/getPassword';
 
 export * from './storage/onObjectFinalized/user/onHeadshotUpload';
 export * from './storage/onObjectFinalized/file/onFileUploadEncrypt';
-export * from './storage/onObjectFinalized/file/onFileUploadVirusChecks';

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -20,3 +20,4 @@ export * from './https/onCall/file/getPassword';
 
 export * from './storage/onObjectFinalized/user/onHeadshotUpload';
 export * from './storage/onObjectFinalized/file/onFileUploadEncrypt';
+export * from './storage/onObjectFinalized/file/onFileUploadVirusChecks';


### PR DESCRIPTION
IGNORE THE BRANCH NAME virus total is a scam, this is the refinements to the file upload page to make it so that it stores the uploaded file into the correct storage bucket. This function is also now operating in production so please reference the actual firebase storage and not emulator